### PR TITLE
Fix YAML frontmatter parsing error in check-modern-code agent

### DIFF
--- a/Templates/Agents/check-modern-code.md
+++ b/Templates/Agents/check-modern-code.md
@@ -1,8 +1,8 @@
 ---
-meta: "Template Version: 6 | ContextKit: 0.2.0 | Updated: 2025-10-02"
+meta: "Template Version: 7 | ContextKit: 0.2.0 | Updated: 2024-11-05"
 name: check-modern-code
 description: [INCOMPLETE] Detect and replace outdated APIs with modern alternatives - needs rework for read-only reporting
-tools: Read, Edit, MultiEdit, Grep, Glob, Bash, Task
+tools: [Read, Edit, MultiEdit, Grep, Glob, Bash, Task]
 color: cyan
 ---
 


### PR DESCRIPTION
## Summary
Fix invalid YAML frontmatter in `check-modern-code.md` agent that prevents proper loading in Claude Code.

## Problem
The `tools` field on line 5 was using an unquoted comma-separated list:
```yaml
tools: Read, Edit, MultiEdit, Grep, Glob, Bash, Task
```

This causes YAML parsing errors because unquoted comma-separated values are interpreted as multiline keys, breaking Claude Code's ability to parse the agent's frontmatter metadata.

## Solution
Convert to proper YAML array format:
```yaml
tools: [Read, Edit, MultiEdit, Grep, Glob, Bash, Task]
```

## Why This Matters
- **Claude Code Functionality**: Claude Code parses YAML frontmatter to determine which tools an agent can use
- **Agent Loading**: Invalid YAML prevents the agent from loading correctly, breaking tool detection
- **User Experience**: Users attempting to use this agent template get parsing errors instead of functional behavior
- **Easy Fix**: Simple syntax correction that ensures proper agent functionality

## Changes Made
- ✅ Convert tools field to proper YAML array format
- ✅ Increment Template Version from 6 to 7 (per contribution guidelines)
- ✅ Update date to 2024-11-05 (per contribution guidelines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)